### PR TITLE
Fix: fix the darkmode error and the error of responsive web design

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,13 @@
 <html lang="en" class="scroll-smooth">
   <head>
     <meta charset="UTF-8" />
+
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>PROlog</title>
+    <script>
+      localStorage.theme = 'light';
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/assets/icons/magnifyingGlass.svg
+++ b/src/assets/icons/magnifyingGlass.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" width='current' height='current' class="w-6 h-6">
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="current" width='current' height='current' class="w-6 h-6">
   <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
 </svg>

--- a/src/components/molecules/SearchBar.tsx
+++ b/src/components/molecules/SearchBar.tsx
@@ -13,10 +13,10 @@ const SearchBar = () => {
   return (
     <div className="flex items-center bg-gray-200 rounded-full p-2 w-full">
       <div className="flex-shrink-0">
-        <MagnifyingGlassIcon width={16} height={16} />
+        <MagnifyingGlassIcon width={16} height={16} stroke="black" />
       </div>
       <input
-        className="ml-2 bg-transparent outline-none placeholder-gray-500 flex-grow"
+        className="ml-2 bg-transparent outline-none text-black placeholder-gray-500 flex-grow"
         type="text"
         value={searchWord}
         onChange={(e) => setSearchWord(e.target.value)}

--- a/src/components/molecules/WriteBtn.tsx
+++ b/src/components/molecules/WriteBtn.tsx
@@ -19,7 +19,9 @@ const WriteBtn = () => {
         width={16}
         stroke={darkMode ? 'white' : 'black'}
       />
-      <div className="font-pretendard text-bold dark:text-white ">글쓰기</div>
+      <div className="font-pretendard text-bold text-black dark:text-white ">
+        글쓰기
+      </div>
     </button>
   );
 };

--- a/src/components/organisms/BoardCard.tsx
+++ b/src/components/organisms/BoardCard.tsx
@@ -23,7 +23,7 @@ const BoardCard: React.FC<Props> = ({
 
   return (
     <div
-      className="font-pretendard w-1/3 h-auto bg-white dark:bg-zinc-700 text-zinc-700 dark:text-white border-b-2
+      className="font-pretendard w-full md:w-1/3 h-auto bg-white dark:bg-zinc-700 text-zinc-700 dark:text-white border-b-2
     overflow-hidden p-4 flex flex-col justify-between cursor-pointer transform transition-all duration-300 ease-in-out hover:scale-105"
       onClick={onClick}
     >

--- a/src/components/organisms/BoardHeader.tsx
+++ b/src/components/organisms/BoardHeader.tsx
@@ -20,7 +20,11 @@ const BoardHeader = () => {
       </div>
 
       <div className="flex items-center gap-x-4">
-        <HeaderNickName title="닉네임" />
+        {/* 화면 크기가 md 이상에서만 닉네임 표시 */}
+        <div className="hidden md:block">
+          <HeaderNickName title="닉네임" />
+        </div>
+
         <div className="cursor-pointer " onClick={() => navigate('/my')}>
           <UserIcon
             width={16}

--- a/src/components/organisms/CommentWrite.tsx
+++ b/src/components/organisms/CommentWrite.tsx
@@ -16,7 +16,9 @@ const CommentWrite: React.FC = () => {
 
   return (
     <div className="font-pretendard mt-8 sm:mx-32 flex flex-col">
-      <div className="text-xl font-semibold dark:text-white">댓글</div>
+      <div className="text-xl font-semibold text-black dark:text-white">
+        댓글
+      </div>
 
       <form onSubmit={handleCommentSubmit} className="mt-4">
         <textarea

--- a/src/index.css
+++ b/src/index.css
@@ -5,13 +5,11 @@
 @tailwind utilities;
 
 :root {
+  color-scheme: light;
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -19,14 +17,14 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
+/* a {
   font-weight: 500;
   color: #646cff;
   text-decoration: inherit;
 }
 a:hover {
   color: #535bf2;
-}
+} */
 
 body {
   margin: 0;
@@ -36,10 +34,10 @@ body {
   min-height: 100vh;
 }
 
-h1 {
+/* h1 {
   font-size: 3.2em;
   line-height: 1.1;
-}
+} */
 
 /* button {
   border-radius: 8px;
@@ -52,15 +50,15 @@ h1 {
   cursor: pointer;
   transition: border-color 0.25s;
 } */
-button:hover {
+/* button:hover {
   border-color: #646cff;
 }
 button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
-}
+} */
 
-@media (prefers-color-scheme: light) {
+/* @media (prefers-color-scheme: light) {
   :root {
     color: #213547;
     background-color: #ffffff;
@@ -71,4 +69,4 @@ button:focus-visible {
   button {
     background-color: #f9f9f9;
   }
-}
+} */

--- a/src/pages/Content.tsx
+++ b/src/pages/Content.tsx
@@ -23,7 +23,7 @@ const Content: React.FC = () => {
   return (
     <div className="min-h-screen w-screen bg-white dark:bg-zinc-700 flex flex-col px-8 ">
       <BoardHeader />
-      <div className="font-pretendard sm:mx-32 mt-20">
+      <div className="font-pretendard text-black sm:mx-32 mt-20">
         <div className="text-2xl font-bold dark:text-white mt-4">
           {content.title}
         </div>

--- a/src/pages/My.tsx
+++ b/src/pages/My.tsx
@@ -34,9 +34,11 @@ const My = () => {
       <div className="h-64 mt-3 flex-shrink-0">
         <MyIntroduce />
       </div>
-      <div className="font-pretendard sm:mx-32 mb-10 px-8">
-        <div className="flex justify-between items-center my-20">
-          <div className="text-xl font-semibold dark:text-white">닉네임</div>
+      <div className="font-pretendard md:mx-32 mb-10 px-8">
+        <div className="flex flex-col gap-y-8 my-20">
+          <div className="text-xl font-semibold text-black dark:text-white">
+            닉네임
+          </div>
           <div className="flex items-center gap-x-4">
             {isEditing ? (
               <input
@@ -46,7 +48,9 @@ const My = () => {
                 className="text-lg rounded-lg border-2"
               />
             ) : (
-              <div className="text-lg dark:text-white ">{nickname}</div>
+              <div className="text-lg text-black dark:text-white ">
+                {nickname}
+              </div>
             )}
             <div className="mr-4">
               <BlueBtn title="변경" onClick={handleEditClick} />
@@ -55,7 +59,7 @@ const My = () => {
         </div>
 
         <hr className="border-gray-300 dark:border-white mt-4" />
-        <div className="text-xl font-semibold dark:text-white mt-10">
+        <div className="text-xl font-semibold text-black dark:text-white mt-10">
           내가 쓴 글
         </div>
       </div>
@@ -86,7 +90,7 @@ const My = () => {
           3
         </button>
       </div>
-      <div className="font-pretendard sm:mx-32 mt-20 mb-20 px-8">
+      <div className="font-pretendard md:mx-32 mt-20 mb-20 px-8">
         <div className="float-right">
           <RedBtn title="탈퇴하기" />
         </div>

--- a/src/pages/My.tsx
+++ b/src/pages/My.tsx
@@ -52,7 +52,7 @@ const My = () => {
                 {nickname}
               </div>
             )}
-            <div className="mr-4">
+            <div className="mr-4 whitespace-nowrap">
               <BlueBtn title="변경" onClick={handleEditClick} />
             </div>
           </div>

--- a/src/pages/Register/Register1.tsx
+++ b/src/pages/Register/Register1.tsx
@@ -18,7 +18,7 @@ const Register1 = () => {
       >
         <IntroHeader />
         <div
-          className="font-pretendard bg-gray-200 p-4 rounded max-w-sm mx-auto transition-opacity duration-1000"
+          className="font-pretendard bg-gray-200 text-black p-4 rounded max-w-sm mx-auto transition-opacity duration-1000"
           style={{ opacity }}
         >
           <div className="text-xl font-bold mb-2">PROlog 개인정보 처리방침</div>

--- a/src/pages/Register/Register2.tsx
+++ b/src/pages/Register/Register2.tsx
@@ -37,7 +37,7 @@ const Register2 = () => {
           className="font-pretendard bg-gray-200 p-4 rounded max-w-md mx-auto transition-opacity duration-1000 "
           style={{ opacity }}
         >
-          <div className="text-xl font-bold ">이메일</div>
+          <div className="text-xl font-bold text-black">이메일</div>
           <div className="flex items-center gap-x-2 mt-2">
             <input
               type="email"
@@ -49,7 +49,7 @@ const Register2 = () => {
             <BlueBtn title="중복 검사" />
           </div>
 
-          <div className="text-xl font-bold mt-2 ">닉네임</div>
+          <div className="text-xl font-bold mt-2 text-black ">닉네임</div>
           <div className="flex items-center gap-x-2 mt-2">
             <input
               type="text"
@@ -61,7 +61,7 @@ const Register2 = () => {
             <BlueBtn title="중복 검사" />
           </div>
 
-          <div className="text-xl font-bold mt-2 ">비밀번호</div>
+          <div className="text-xl font-bold mt-2 text-black ">비밀번호</div>
           <div className="flex items-center gap-x-2 mt-2">
             <input
               type="password"
@@ -72,7 +72,7 @@ const Register2 = () => {
             />
           </div>
 
-          <div className="text-xl font-bold mt-2 ">비밀번호 확인</div>
+          <div className="text-xl font-bold mt-2 text-black">비밀번호 확인</div>
           <div className="flex items-center gap-x-2 mt-2">
             <input
               type="password"

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -9,7 +9,7 @@ const Search = () => {
     <div className="min-h-screen w-screen bg-white dark:bg-zinc-700 flex flex-col px-8 ">
       <BoardHeader />
       <div className="font-pretendard sm:mx-32 mt-20">
-        <div className="text-2xl font-bold dark:text-white mt-4">
+        <div className="text-2xl font-bold text-black dark:text-white mt-4">
           '{searchWord}' 검색 결과
         </div>
       </div>

--- a/src/pages/Write.tsx
+++ b/src/pages/Write.tsx
@@ -45,7 +45,7 @@ const Write = () => {
   return (
     <div className="min-h-screen w-screen bg-white flex flex-col px-8">
       <BoardHeader />
-      <div className="font-pretendard sm:mx-32 mt-10">
+      <div className="font-pretendard text-black sm:mx-32 mt-10">
         <form onSubmit={handleWritingSubmit} className="mt-4">
           <div className="text-xl font-semibold dark:text-white">제목</div>
           <input


### PR DESCRIPTION
1. 웹사이트가 light 모드이고 웹브라우저가 dark 모드일 때 글씨들이 표시되지 않던 오류를 수정했습니다.
-> light 모드일 때 text-black을 지정해주지 않고 dark 모드일 때에만 text color를 지정해줘서 생긴 문제입니다.

2. 모바일에서 화면이 제대로 표시되지 않는 오류를 수정했습니다.
- BoardHeader에서 화면이 md보다 작아지면 닉네임을 표시되지 않게 수정했습니다.
- My 페이지에서 닉네임 변경 버튼의 텍스트가 두 줄로 넘어가지 않게 변경했습니다.
- My 페이지에서 닉네임 제목과 변경하는 부분을 한 줄로 놓지 않고 분리했습니다.
- Card 컴포넌트가 md보다 작을 때는 width를 full로, md보다 클 때는 width를 1/3으로 설정되게 변경했습니다.
- Card 컴포넌트의 width가 변경됨에 따라 그와 같은 페이지의 margin도 반응되도록 변경했습니다.