### PR TITLE
Fix: fix the error of the type 'quill-image-drop-module' and apply drag and drop in quill editor

### DIFF
--- a/src/components/organisms/WritingEditor.tsx
+++ b/src/components/organisms/WritingEditor.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useRef } from 'react';
-import ReactQuill from 'react-quill';
-// import ImageDrop from 'quill-image-drop-module';
+import ReactQuill, { Quill } from 'react-quill';
+import { ImageDrop } from 'quill-image-drop-module';
 import 'react-quill/dist/quill.snow.css';
 
 interface Props {
@@ -8,7 +8,7 @@ interface Props {
   onChange: (e: string) => void;
 }
 
-// Quill.register('modules/imageDrop', ImageDrop);
+Quill.register('modules/imageDrop', ImageDrop);
 
 const WritingEditor: React.FC<Props> = ({ value, onChange }) => {
   const toolbarOptions = [
@@ -47,7 +47,7 @@ const WritingEditor: React.FC<Props> = ({ value, onChange }) => {
       toolbar: {
         container: toolbarOptions,
       },
-      // imageDrop: true,
+      imageDrop: true,
     }),
     []
   );

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -4,3 +4,5 @@ declare module '*.svg' {
   const src: string;
   export default src;
 }
+
+declare module 'quill-image-drop-module';

--- a/src/pages/My.tsx
+++ b/src/pages/My.tsx
@@ -34,11 +34,9 @@ const My = () => {
       <div className="h-64 mt-3 flex-shrink-0">
         <MyIntroduce />
       </div>
-      <div className="font-pretendard md:mx-32 mb-10 px-8">
-        <div className="flex flex-col gap-y-8 my-20">
-          <div className="text-xl font-semibold text-black dark:text-white">
-            닉네임
-          </div>
+      <div className="font-pretendard sm:mx-32 mb-10 px-8">
+        <div className="flex justify-between items-center my-20">
+          <div className="text-xl font-semibold dark:text-white">닉네임</div>
           <div className="flex items-center gap-x-4">
             {isEditing ? (
               <input
@@ -48,18 +46,16 @@ const My = () => {
                 className="text-lg rounded-lg border-2"
               />
             ) : (
-              <div className="text-lg text-black dark:text-white ">
-                {nickname}
-              </div>
+              <div className="text-lg dark:text-white ">{nickname}</div>
             )}
-            <div className="mr-4 whitespace-nowrap">
+            <div className="mr-4">
               <BlueBtn title="변경" onClick={handleEditClick} />
             </div>
           </div>
         </div>
 
         <hr className="border-gray-300 dark:border-white mt-4" />
-        <div className="text-xl font-semibold text-black dark:text-white mt-10">
+        <div className="text-xl font-semibold dark:text-white mt-10">
           내가 쓴 글
         </div>
       </div>
@@ -90,7 +86,7 @@ const My = () => {
           3
         </button>
       </div>
-      <div className="font-pretendard md:mx-32 mt-20 mb-20 px-8">
+      <div className="font-pretendard sm:mx-32 mt-20 mb-20 px-8">
         <div className="float-right">
           <RedBtn title="탈퇴하기" />
         </div>


### PR DESCRIPTION
quill-image-drop-module의 타입을 못 찾아서 오류가 발생하는 현상을 수정했습니다.
따라서 이제는 quill editor에서 사진을 드래그 앤 드롭으로 가져올 수 있습니다.