### PR TITLE
Fix: resize the input area in the search bar

### DIFF
--- a/src/components/molecules/SearchBar.tsx
+++ b/src/components/molecules/SearchBar.tsx
@@ -16,7 +16,7 @@ const SearchBar = () => {
         <MagnifyingGlassIcon width={16} height={16} stroke="black" />
       </div>
       <input
-        className="ml-2 bg-transparent outline-none text-black placeholder-gray-500 flex-grow"
+        className="ml-2 bg-transparent outline-none text-black placeholder-gray-500 flex-grow overflow-x-auto"
         type="text"
         value={searchWord}
         onChange={(e) => setSearchWord(e.target.value)}

--- a/src/components/organisms/LoginArea.tsx
+++ b/src/components/organisms/LoginArea.tsx
@@ -12,12 +12,12 @@ const LoginArea = () => {
     >
       <div className="text-left font-semibold text-black text-xl">로그인</div>
       <input
-        className="bg-gray-200 border-b-2  border-gray-500 p-2"
+        className="bg-gray-200 border-b-2  border-gray-500 p-2 text-black"
         type="text"
         placeholder="이메일"
       />
       <input
-        className="bg-gray-200 border-b-2 border-gray-500 p-2"
+        className="bg-gray-200 border-b-2 border-gray-500 p-2 text-black"
         type="password"
         placeholder="비밀번호"
       />

--- a/src/pages/Register/Register2.tsx
+++ b/src/pages/Register/Register2.tsx
@@ -43,7 +43,7 @@ const Register2 = () => {
               type="email"
               value={email}
               onChange={handleEmailChange}
-              className="border-2 border-gray-200 p-2 w-64"
+              className="border-2 border-gray-200 p-2 w-64 text-black"
               placeholder="이메일을 입력하세요"
             />
             <BlueBtn title="중복 검사" />
@@ -55,7 +55,7 @@ const Register2 = () => {
               type="text"
               value={nickname}
               onChange={handleNicknameChange}
-              className="border-2 border-gray-200 p-2 w-64"
+              className="border-2 border-gray-200 p-2 w-64 text-black"
               placeholder="닉네임을 입력하세요"
             />
             <BlueBtn title="중복 검사" />
@@ -67,7 +67,7 @@ const Register2 = () => {
               type="password"
               value={password}
               onChange={handlePasswordChange}
-              className="border-2 border-gray-200 p-2 w-64"
+              className="border-2 border-gray-200 p-2 w-64 text-black"
               placeholder="비밀번호를 입력하세요"
             />
           </div>
@@ -78,7 +78,7 @@ const Register2 = () => {
               type="password"
               value={passwordCheck}
               onChange={handlePasswordCheckChange}
-              className="border-2 border-gray-200 p-2 w-64"
+              className="border-2 border-gray-200 p-2 w-64 text-black"
               placeholder="비밀번호를 다시 입력하세요"
             />
           </div>


### PR DESCRIPTION
1. BoardHeader에 있는 SearchBar의 input이 모바일 화면에서는 회색 배경을 넘어가는 오류를 수정했습니다.(overflow-x-auto 적용)
2. 로그인과 회원가입 할 때 input에 text-black을 적용해서 가시성을 확보했습니다.